### PR TITLE
DEV-452: Add .mjs MIME type to nginx config

### DIFF
--- a/nginx/1.15.12/files/scripts/run.sh
+++ b/nginx/1.15.12/files/scripts/run.sh
@@ -13,6 +13,9 @@ error_log stderr info;
 
 http {
   include       mime.types;
+  types {
+    application/javascript  mjs;
+  }
   default_type  application/octet-stream;
 
   sendfile on;


### PR DESCRIPTION
## Summary

- Add `application/javascript` MIME type mapping for `.mjs` files in the nginx 1.15.12 config
- Without this, `.mjs` files (ES modules) may be served with an incorrect content type, causing browsers to reject them

## Linear issue

https://linear.app/the-dutch-selection/issue/DEV-452/add-mjs-mime-type-to-nginx-config

## Testing

- Verify `.mjs` files are served with `application/javascript` content type